### PR TITLE
add serviceContext.service to logs for nicer error reporting

### DIFF
--- a/fluidly-structlog/fluidly/structlog/base_logger.py
+++ b/fluidly-structlog/fluidly/structlog/base_logger.py
@@ -53,31 +53,28 @@ def add_service_context(logger: Any, method_name: str, event_dict: Dict) -> Dict
     return event_dict
 
 
-structlog.configure(
-    processors=[
-        filter_by_level,
-        structlog.processors.format_exc_info,
-        add_log_level_as_severity,
-        add_service_context,
-        structlog.processors.TimeStamper(fmt="iso"),
-        structlog.dev.ConsoleRenderer()
-        if "PRETTY_LOGS" in os.environ
-        else structlog.processors.JSONRenderer(),
-    ],
-    context_class=wrap_dict(dict),
-)
-
-get_logger = structlog.get_logger
-
-
 def unhandled_exception_hook(exception_type, exception, traceback):
+    """Hook to make sure the log processors are applied to unhandled exceptions as well"""
     logger = get_logger()
     logger.exception(
         "Unhandled Exception", exc_info=(exception_type, exception, traceback)
     )
 
 
-def setup_logging():
-    """Add a sys.excepthook so that the log processors are applied and there is nice
-    error log in gcp"""
-    sys.excepthook = unhandled_exception_hook
+def get_logger():
+    if not structlog.is_configured():
+        structlog.configure(
+            processors=[
+                filter_by_level,
+                structlog.processors.format_exc_info,
+                add_log_level_as_severity,
+                add_service_context,
+                structlog.processors.TimeStamper(fmt="iso"),
+                structlog.dev.ConsoleRenderer()
+                if "PRETTY_LOGS" in os.environ
+                else structlog.processors.JSONRenderer(),
+            ],
+            context_class=wrap_dict(dict),
+        )
+        sys.excepthook = unhandled_exception_hook  # Overriding the default excepthook for better logging of unhandled exceptions
+    return structlog.get_logger()

--- a/fluidly-structlog/fluidly/structlog/base_logger.py
+++ b/fluidly-structlog/fluidly/structlog/base_logger.py
@@ -46,8 +46,8 @@ def add_log_level_as_severity(logger: Any, method_name: str, event_dict: Dict) -
 
 
 def add_service_context(logger: Any, method_name: str, event_dict: Dict) -> Dict:
-    """Add serviceContext.service if the env variable SERVICE_NAME is set for error reporting in gcp"""
-    service_name = os.getenv("SERVICE_NAME")
+    """Add serviceContext.service if the env variable APPLICATION_NAME is set for error reporting in gcp"""
+    service_name = os.getenv("APPLICATION_NAME")
     if service_name:
         event_dict["serviceContext"] = {"service": service_name}
     return event_dict

--- a/fluidly-structlog/fluidly/structlog/base_logger.py
+++ b/fluidly-structlog/fluidly/structlog/base_logger.py
@@ -70,14 +70,14 @@ structlog.configure(
 get_logger = structlog.get_logger
 
 
-def unhandeld_exception_hook(exception_type, exception, traceback):
+def unhandled_exception_hook(exception_type, exception, traceback):
     logger = get_logger()
     logger.exception(
-        "Unhandeld Exception", exc_info=(exception_type, exception, traceback)
+        "Unhandled Exception", exc_info=(exception_type, exception, traceback)
     )
 
 
 def setup_logging():
     """Add a sys.excepthook so that the log processors are applied and there is nice
     error log in gcp"""
-    sys.excepthook = unhandeld_exception_hook
+    sys.excepthook = unhandled_exception_hook

--- a/fluidly-structlog/setup.py
+++ b/fluidly-structlog/setup.py
@@ -11,7 +11,7 @@ URL = "https://github.com/fluidly/python-shared"
 EMAIL = "tech@fluidly.com"
 AUTHOR = "Fluidly"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "0.1.5"
+VERSION = "0.1.6"
 
 REQUIRED = ["structlog"]
 

--- a/fluidly-structlog/tests/test_base_logger.py
+++ b/fluidly-structlog/tests/test_base_logger.py
@@ -33,7 +33,7 @@ def test_filter_by_level_with_unknown_method():
 
 
 def test_add_service_context_when_env_set(monkeypatch):
-    monkeypatch.setenv("SERVICE_NAME", "fluidly-service")
+    monkeypatch.setenv("APPLICATION_NAME", "fluidly-service")
     event = add_service_context(None, "some_method", {})
 
     assert event["serviceContext"]["service"] == "fluidly-service"

--- a/fluidly-structlog/tests/test_base_logger.py
+++ b/fluidly-structlog/tests/test_base_logger.py
@@ -1,7 +1,11 @@
 import pytest
 import structlog
 
-from fluidly.structlog.base_logger import filter_by_level, get_logger
+from fluidly.structlog.base_logger import (
+    add_service_context,
+    filter_by_level,
+    get_logger,
+)
 
 
 def test_get_logger():
@@ -26,3 +30,16 @@ def test_filter_by_level():
 
 def test_filter_by_level_with_unknown_method():
     assert filter_by_level(object(), "foo", {"key": "value"})  # not dropped
+
+
+def test_add_service_context_when_env_set(monkeypatch):
+    monkeypatch.setenv("SERVICE_NAME", "fluidly-service")
+    event = add_service_context(None, "some_method", {})
+
+    assert event["serviceContext"]["service"] == "fluidly-service"
+
+
+def test_add_service_context_does_nothing_when_not_env():
+    event = add_service_context(None, "some_method", {})
+
+    assert event == {}


### PR DESCRIPTION
- Adding `serviceContext.service` to our logs so that it gets picked up by error reporting in gcp, which means we would get the service name in error notification and in the error reporting dashboard.
- Adding an unhandled exception hook so we apply our log processors to unhandeld exception as well
 - Fixing critcal typo

Are we ok with setting the `SERVICE_NAME` env variable in kubernetes or is there a nicer way to that ? (we could for example get the hostname == pod name and do some parsing but I don't think it's nicer - and I am not sure that would work everytime)

More of a personal style thing but I would prefer to move `structlog.configure` inside `setup_logging` so we don't have side effects when importing the module and we would call `setup_logging` on startup.