### PR TITLE
Support base64 decoding strings as well as bytestrings

### DIFF
--- a/fluidly-flask/.bumpversion.cfg
+++ b/fluidly-flask/.bumpversion.cfg
@@ -1,4 +1,4 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.1.1
 
 [bumpversion:file:setup.py]

--- a/fluidly-flask/fluidly/flask/utils.py
+++ b/fluidly-flask/fluidly/flask/utils.py
@@ -8,6 +8,8 @@ def base64_decode(encoded_str):
 
     https://en.wikipedia.org/wiki/Base64#Output_padding
     """
+    if isinstance(encoded_str, str):
+        encoded_str = encoded_str.encode("utf-8")
 
     num_missed_paddings = 4 - len(encoded_str) % 4
     if num_missed_paddings != 4:

--- a/fluidly-flask/setup.py
+++ b/fluidly-flask/setup.py
@@ -11,7 +11,7 @@ URL = "https://github.com/fluidly/python-shared"
 EMAIL = "tech@fluidly.com"
 AUTHOR = "Fluidly"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "0.1.0"
+VERSION = "0.1.1"
 
 
 def local_dependencies(*packages):

--- a/fluidly-flask/tests/test_base64_decode.py
+++ b/fluidly-flask/tests/test_base64_decode.py
@@ -1,0 +1,18 @@
+import base64
+import json
+
+from fluidly.flask.utils import base64_decode
+
+
+def test_decode_bytestring():
+    obj = {"foo": "bar"}
+    payload = base64.b64encode(json.dumps(obj).encode("utf-8"))
+
+    assert json.loads(base64_decode(payload)) == obj
+
+
+def test_decode_string():
+    obj = {"foo": "bar"}
+    payload = base64.b64encode(json.dumps(obj).encode("utf-8")).decode("utf-8")
+
+    assert json.loads(base64_decode(payload)) == obj


### PR DESCRIPTION
Let's try this first for `fluidly-flask`. If it works, then we can port it to `fluidly-fastapi` too

```
Traceback (most recent call last):
  File "/app/.local/share/virtualenvs/src-sjxfABcx/lib/python3.9/site-packages/fluidly/flask/exception_handling.py", line 14, in decorated_function
    result = func(*args, **kwargs)
  File "/app/.local/share/virtualenvs/src-sjxfABcx/lib/python3.9/site-packages/fluidly/flask/exception_handling.py", line 39, in decorated_function
    return func(*args, **kwargs)
  File "/app/.local/share/virtualenvs/src-sjxfABcx/lib/python3.9/site-packages/fluidly/flask/decorators.py", line 66, in decorated_function
    info_json = base64_decode(encoded_info)
  File "/app/.local/share/virtualenvs/src-sjxfABcx/lib/python3.9/site-packages/fluidly/flask/utils.py", line 14, in base64_decode
    encoded_str += b"=" * num_missed_paddings
TypeError: can only concatenate str (not "bytes") to str

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/app/.local/share/virtualenvs/src-sjxfABcx/lib/python3.9/site-packages/fluidly/flask/rest_logger.py", line 23, in decorated_function
    result = func(*args, **kwargs)
  File "/app/.local/share/virtualenvs/src-sjxfABcx/lib/python3.9/site-packages/fluidly/flask/exception_handling.py", line 28, in decorated_function
    raise APIException(status=500, title="An unknown error occurred")
```