### PR TITLE
support esp v2 flask

### DIFF
--- a/fluidly-flask/.bumpversion.cfg
+++ b/fluidly-flask/.bumpversion.cfg
@@ -1,4 +1,4 @@
 [bumpversion]
-current_version = 0.1.1
+current_version = 0.1.2
 
 [bumpversion:file:setup.py]

--- a/fluidly-flask/fluidly/flask/decorators.py
+++ b/fluidly-flask/fluidly/flask/decorators.py
@@ -68,7 +68,11 @@ def admin(f):
         user_info = json.loads(info_json)
         # Claims are given as a string by Cloud Endpoints so we have
         # to parse the claims attribute
-        claims = json.loads(user_info.get("claims", "{}"))
+        if "claims" in user_info:
+            claims = json.loads(user_info.get("claims", "{}"))
+        else:
+            # Support ESPv2
+            claims = user_info
 
         auth0_claims = claims.get("https://api.fluidly.com/app_metadata", {})
         internal_claims = claims.get("https://api.fluidly.com/internal_metadata", {})

--- a/fluidly-flask/fluidly/flask/decorators.py
+++ b/fluidly-flask/fluidly/flask/decorators.py
@@ -24,7 +24,12 @@ def authorised(f):
 
         decoded_user_info = base64_decode(encoded_user_info)
         user_info = json.loads(decoded_user_info)
-        claims = json.loads(user_info.get("claims", "{}"))
+
+        if "claims" in user_info:
+            claims = json.loads(user_info.get("claims", "{}"))
+        else:
+            # Support ESPv2
+            claims = user_info
 
         auth0_claims = claims.get("https://api.fluidly.com/app_metadata", {})
         internal_claims = claims.get("https://api.fluidly.com/internal_metadata", {})

--- a/fluidly-flask/setup.py
+++ b/fluidly-flask/setup.py
@@ -11,7 +11,7 @@ URL = "https://github.com/fluidly/python-shared"
 EMAIL = "tech@fluidly.com"
 AUTHOR = "Fluidly"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "0.1.1"
+VERSION = "0.1.2"
 
 
 def local_dependencies(*packages):

--- a/fluidly-flask/tests/test_decorators.py
+++ b/fluidly-flask/tests/test_decorators.py
@@ -144,6 +144,20 @@ class TestAuthorisedESPv1:
         assert response.data == b"some:connection_id"
 
 
+class TestAuthorisedESPv2(TestAuthorisedESPv1):
+    @staticmethod
+    def _get_dummy_user_info(**kwargs):
+        app_metadata = kwargs.get("app_metadata", {})
+        internal_metadata = kwargs.get("internal_metadata", {})
+
+        return TestAuthorisedESPv2._encode_claims(
+            {
+                "https://api.fluidly.com/app_metadata": {**app_metadata},
+                "https://api.fluidly.com/internal_metadata": {**internal_metadata},
+            }
+        )
+
+
 class TestAdminESPv1:
     @staticmethod
     def _encode_claims(claims):

--- a/fluidly-flask/tests/test_decorators.py
+++ b/fluidly-flask/tests/test_decorators.py
@@ -229,7 +229,6 @@ class TestAdminESPv1:
         assert response.status_code == 200
 
 
-@pytest.mark.skip
 class TestAdminESPv2(TestAdminESPv1):
     @staticmethod
     def _get_dummy_user_info(**kwargs):

--- a/fluidly-flask/tests/test_decorators.py
+++ b/fluidly-flask/tests/test_decorators.py
@@ -57,7 +57,7 @@ def mocked_admin_given_permissions(monkeypatch):
     yield check_admin_permissions_mock
 
 
-class TestAuthorised:
+class TestAuthorisedESPv1:
     @staticmethod
     def _encode_claims(claims):
         return base64.b64encode(json.dumps(claims).encode("utf-8"))
@@ -67,7 +67,7 @@ class TestAuthorised:
         app_metadata = kwargs.get("app_metadata", {})
         internal_metadata = kwargs.get("internal_metadata", {})
 
-        return TestAuthorised._encode_claims(
+        return TestAuthorisedESPv1._encode_claims(
             {
                 "claims": json.dumps(
                     {
@@ -92,7 +92,7 @@ class TestAuthorised:
     def test_permissions_unavailable(self, client):
         response = client.get(
             "/shared/authorised/some:connection_id",
-            headers={"X-Endpoint-API-UserInfo": TestAuthorised._get_dummy_user_info()},
+            headers={"X-Endpoint-API-UserInfo": self._get_dummy_user_info()},
         )
         assert response.status_code == 403
         assert response.json == {
@@ -106,7 +106,7 @@ class TestAuthorised:
     ):
         response = client.get(
             "/shared/authorised/some:connection_id",
-            headers={"X-Endpoint-API-UserInfo": TestAuthorised._get_dummy_user_info()},
+            headers={"X-Endpoint-API-UserInfo": self._get_dummy_user_info()},
         )
         assert response.status_code == 403
         assert response.json == {
@@ -121,7 +121,7 @@ class TestAuthorised:
         response = client.get(
             "/shared/authorised/some:connection_id",
             headers={
-                "X-Endpoint-API-UserInfo": TestAuthorised._get_dummy_user_info(
+                "X-Endpoint-API-UserInfo": self._get_dummy_user_info(
                     app_metadata={"userId": 2}
                 )
             },
@@ -135,7 +135,7 @@ class TestAuthorised:
         response = client.get(
             "/shared/authorised/some:connection_id",
             headers={
-                "X-Endpoint-API-UserInfo": TestAuthorised._get_dummy_user_info(
+                "X-Endpoint-API-UserInfo": self._get_dummy_user_info(
                     internal_metadata={"isServiceAccount": True}
                 )
             },

--- a/fluidly-flask/tests/test_decorators.py
+++ b/fluidly-flask/tests/test_decorators.py
@@ -179,7 +179,7 @@ class TestAdminESPv1:
     def test_admin_permissions_unavailable(self, client):
         response = client.get(
             "/shared/admin",
-            headers={"X-Endpoint-API-UserInfo": TestAdminESPv1._get_dummy_user_info()},
+            headers={"X-Endpoint-API-UserInfo": self._get_dummy_user_info()},
         )
         assert response.status_code == 403
         assert response.json == {
@@ -193,7 +193,7 @@ class TestAdminESPv1:
     ):
         response = client.get(
             "/shared/admin",
-            headers={"X-Endpoint-API-UserInfo": TestAdminESPv1._get_dummy_user_info()},
+            headers={"X-Endpoint-API-UserInfo": self._get_dummy_user_info()},
         )
         assert response.status_code == 403
         assert response.json == {
@@ -208,7 +208,7 @@ class TestAdminESPv1:
         response = client.get(
             "/shared/admin",
             headers={
-                "X-Endpoint-API-UserInfo": TestAdminESPv1._get_dummy_user_info(
+                "X-Endpoint-API-UserInfo": self._get_dummy_user_info(
                     app_metadata={"userId": 2}
                 )
             },
@@ -221,7 +221,7 @@ class TestAdminESPv1:
         response = client.get(
             "/shared/admin",
             headers={
-                "X-Endpoint-API-UserInfo": TestAdminESPv1._get_dummy_user_info(
+                "X-Endpoint-API-UserInfo": self._get_dummy_user_info(
                     internal_metadata={"isServiceAccount": True}
                 )
             },
@@ -229,6 +229,7 @@ class TestAdminESPv1:
         assert response.status_code == 200
 
 
+@pytest.mark.skip
 class TestAdminESPv2(TestAdminESPv1):
     @staticmethod
     def _get_dummy_user_info(**kwargs):

--- a/fluidly-flask/tests/test_decorators.py
+++ b/fluidly-flask/tests/test_decorators.py
@@ -227,3 +227,17 @@ class TestAdminESPv1:
             },
         )
         assert response.status_code == 200
+
+
+class TestAdminESPv2(TestAdminESPv1):
+    @staticmethod
+    def _get_dummy_user_info(**kwargs):
+        app_metadata = kwargs.get("app_metadata", {})
+        internal_metadata = kwargs.get("internal_metadata", {})
+
+        return TestAdminESPv2._encode_claims(
+            {
+                "https://api.fluidly.com/app_metadata": {**app_metadata},
+                "https://api.fluidly.com/internal_metadata": {**internal_metadata},
+            }
+        )

--- a/fluidly-flask/tests/test_decorators.py
+++ b/fluidly-flask/tests/test_decorators.py
@@ -144,7 +144,7 @@ class TestAuthorised:
         assert response.data == b"some:connection_id"
 
 
-class TestAdmin:
+class TestAdminESPv1:
     @staticmethod
     def _encode_claims(claims):
         return base64.b64encode(json.dumps(claims).encode("utf-8"))
@@ -154,7 +154,7 @@ class TestAdmin:
         app_metadata = kwargs.get("app_metadata", {})
         internal_metadata = kwargs.get("internal_metadata", {})
 
-        return TestAdmin._encode_claims(
+        return TestAdminESPv1._encode_claims(
             {
                 "claims": json.dumps(
                     {
@@ -179,7 +179,7 @@ class TestAdmin:
     def test_admin_permissions_unavailable(self, client):
         response = client.get(
             "/shared/admin",
-            headers={"X-Endpoint-API-UserInfo": TestAdmin._get_dummy_user_info()},
+            headers={"X-Endpoint-API-UserInfo": TestAdminESPv1._get_dummy_user_info()},
         )
         assert response.status_code == 403
         assert response.json == {
@@ -193,7 +193,7 @@ class TestAdmin:
     ):
         response = client.get(
             "/shared/admin",
-            headers={"X-Endpoint-API-UserInfo": TestAdmin._get_dummy_user_info()},
+            headers={"X-Endpoint-API-UserInfo": TestAdminESPv1._get_dummy_user_info()},
         )
         assert response.status_code == 403
         assert response.json == {
@@ -208,7 +208,7 @@ class TestAdmin:
         response = client.get(
             "/shared/admin",
             headers={
-                "X-Endpoint-API-UserInfo": TestAdmin._get_dummy_user_info(
+                "X-Endpoint-API-UserInfo": TestAdminESPv1._get_dummy_user_info(
                     app_metadata={"userId": 2}
                 )
             },
@@ -221,7 +221,7 @@ class TestAdmin:
         response = client.get(
             "/shared/admin",
             headers={
-                "X-Endpoint-API-UserInfo": TestAdmin._get_dummy_user_info(
+                "X-Endpoint-API-UserInfo": TestAdminESPv1._get_dummy_user_info(
                     internal_metadata={"isServiceAccount": True}
                 )
             },


### PR DESCRIPTION
- Rename TestAdmin class
- Subclass TestAdminESPv1 for ESPv2 tests
- Reference its own method, instead of always the class. Allows for subclassing
- Support ESPv2 claims location
- Update TestAuthorised
- Support ESPv2 in Authorised path
