### PR TITLE
Support ESPv2 in FastAPI package

### DIFF
--- a/fluidly-fastapi/.bumpversion.cfg
+++ b/fluidly-fastapi/.bumpversion.cfg
@@ -1,4 +1,4 @@
 [bumpversion]
-current_version = 0.1.2
+current_version = 0.1.3
 
 [bumpversion:file:setup.py]

--- a/fluidly-fastapi/fluidly/fastapi/dependencies/auth.py
+++ b/fluidly-fastapi/fluidly/fastapi/dependencies/auth.py
@@ -78,7 +78,11 @@ def get_admin_user(request: Request) -> Dict[str, Any]:
     user_info = json.loads(info_json)
     # Claims are given as a string by Cloud Endpoints so we have
     # to parse the claims attribute
-    claims = json.loads(user_info.get("claims", "{}"))
+    claims = (
+        json.loads(user_info.get("claims", "{}"))
+        if "claims" in user_info
+        else user_info
+    )
 
     email = claims.get("https://api.fluidly.com/email", None)
     name = claims.get("https://api.fluidly.com/name", None)

--- a/fluidly-fastapi/fluidly/fastapi/dependencies/auth.py
+++ b/fluidly-fastapi/fluidly/fastapi/dependencies/auth.py
@@ -25,7 +25,11 @@ def get_authorised_user(request: Request) -> Dict[str, Any]:
 
     decoded_user_info = base64_decode(encoded_user_info)
     user_info = json.loads(decoded_user_info)
-    claims = json.loads(user_info.get("claims", "{}"))
+    claims = (
+        json.loads(user_info.get("claims", "{}"))
+        if "claims" in user_info
+        else user_info
+    )
 
     email = claims.get("https://api.fluidly.com/email", None)
     name = claims.get("https://api.fluidly.com/name", None)

--- a/fluidly-fastapi/fluidly/fastapi/utils.py
+++ b/fluidly-fastapi/fluidly/fastapi/utils.py
@@ -8,6 +8,8 @@ def base64_decode(encoded_str: bytes) -> str:
 
     https://en.wikipedia.org/wiki/Base64#Output_padding
     """
+    if isinstance(encoded_str, str):
+        encoded_str = encoded_str.encode("utf-8")
 
     num_missed_paddings = 4 - len(encoded_str) % 4
     if num_missed_paddings != 4:

--- a/fluidly-fastapi/setup.py
+++ b/fluidly-fastapi/setup.py
@@ -11,7 +11,7 @@ URL = "https://github.com/fluidly/python-shared"
 EMAIL = "tech@fluidly.com"
 AUTHOR = "Fluidly"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "0.1.2"
+VERSION = "0.1.3"
 
 
 def local_dependencies(*packages):

--- a/fluidly-fastapi/tests/dependencies/test_auth.py
+++ b/fluidly-fastapi/tests/dependencies/test_auth.py
@@ -175,7 +175,7 @@ class TestAuthorisedESPv1(TestAuthBase):
         assert response.json()["user_id"] == None
 
 
-class TestAdmin(TestAuthBase):
+class TestAdminESPv1(TestAuthBase):
     def test_admin_unauthenticated(self):
         response = self.client.get("/shared/admin")
         assert response.status_code == 401
@@ -184,7 +184,7 @@ class TestAdmin(TestAuthBase):
     def test_admin_permissions_unavailable(self):
         response = self.client.get(
             "/shared/admin",
-            headers={"X-Endpoint-API-UserInfo": TestAdmin._get_dummy_user_info()},
+            headers={"X-Endpoint-API-UserInfo": self._get_dummy_user_info()},
         )
         assert response.status_code == 403
         assert response.json() == {
@@ -196,7 +196,7 @@ class TestAdmin(TestAuthBase):
     ):
         response = self.client.get(
             "/shared/admin",
-            headers={"X-Endpoint-API-UserInfo": TestAdmin._get_dummy_user_info()},
+            headers={"X-Endpoint-API-UserInfo": self._get_dummy_user_info()},
         )
         assert response.status_code == 403
         assert response.json() == {"detail": "User cannot access this resource"}
@@ -205,7 +205,7 @@ class TestAdmin(TestAuthBase):
         response = self.client.get(
             "/shared/admin",
             headers={
-                "X-Endpoint-API-UserInfo": TestAdmin._get_dummy_user_info(
+                "X-Endpoint-API-UserInfo": self._get_dummy_user_info(
                     email="bob@burgers.com", name="Bob", app_metadata={"userId": 2}
                 )
             },
@@ -221,7 +221,7 @@ class TestAdmin(TestAuthBase):
         response = self.client.get(
             "/shared/admin",
             headers={
-                "X-Endpoint-API-UserInfo": TestAdmin._get_dummy_user_info(
+                "X-Endpoint-API-UserInfo": self._get_dummy_user_info(
                     app_metadata={"userId": 2}
                 )
             },
@@ -233,7 +233,7 @@ class TestAdmin(TestAuthBase):
         response = self.client.get(
             "/shared/admin",
             headers={
-                "X-Endpoint-API-UserInfo": TestAdmin._get_dummy_user_info(
+                "X-Endpoint-API-UserInfo": self._get_dummy_user_info(
                     app_metadata={"userId": 2}
                 )
             },
@@ -245,7 +245,7 @@ class TestAdmin(TestAuthBase):
         response = self.client.get(
             "/shared/admin",
             headers={
-                "X-Endpoint-API-UserInfo": TestAdmin._get_dummy_user_info(
+                "X-Endpoint-API-UserInfo": self._get_dummy_user_info(
                     internal_metadata={"isServiceAccount": True}
                 )
             },

--- a/fluidly-fastapi/tests/dependencies/test_auth.py
+++ b/fluidly-fastapi/tests/dependencies/test_auth.py
@@ -175,6 +175,24 @@ class TestAuthorisedESPv1(TestAuthBase):
         assert response.json()["user_id"] == None
 
 
+class TestAuthorisedESPv2(TestAuthorisedESPv1):
+    @staticmethod
+    def _get_dummy_user_info(**kwargs):
+        email = kwargs.get("email", None)
+        name = kwargs.get("name", None)
+        app_metadata = kwargs.get("app_metadata", {})
+        internal_metadata = kwargs.get("internal_metadata", {})
+
+        return TestAuthBase._encode_claims(
+            {
+                "https://api.fluidly.com/email": email,
+                "https://api.fluidly.com/name": name,
+                "https://api.fluidly.com/app_metadata": {**app_metadata},
+                "https://api.fluidly.com/internal_metadata": {**internal_metadata},
+            }
+        )
+
+
 class TestAdminESPv1(TestAuthBase):
     def test_admin_unauthenticated(self):
         response = self.client.get("/shared/admin")

--- a/fluidly-fastapi/tests/dependencies/test_auth.py
+++ b/fluidly-fastapi/tests/dependencies/test_auth.py
@@ -270,3 +270,21 @@ class TestAdminESPv1(TestAuthBase):
         )
         assert response.status_code == 200
         assert response.json()["user_id"] == None
+
+
+class TestAdminESPv2(TestAdminESPv1):
+    @staticmethod
+    def _get_dummy_user_info(**kwargs):
+        email = kwargs.get("email", None)
+        name = kwargs.get("name", None)
+        app_metadata = kwargs.get("app_metadata", {})
+        internal_metadata = kwargs.get("internal_metadata", {})
+
+        return TestAuthBase._encode_claims(
+            {
+                "https://api.fluidly.com/email": email,
+                "https://api.fluidly.com/name": name,
+                "https://api.fluidly.com/app_metadata": {**app_metadata},
+                "https://api.fluidly.com/internal_metadata": {**internal_metadata},
+            }
+        )

--- a/fluidly-fastapi/tests/dependencies/test_auth.py
+++ b/fluidly-fastapi/tests/dependencies/test_auth.py
@@ -96,7 +96,7 @@ class TestAuthBase:
         self.client = TestClient(fastapi_app)
 
 
-class TestAuthorised(TestAuthBase):
+class TestAuthorisedESPv1(TestAuthBase):
     def test_user_unauthenticated(self):
         response = self.client.get("/shared/authorised/some:connection_id")
         assert response.status_code == 401
@@ -105,7 +105,7 @@ class TestAuthorised(TestAuthBase):
     def test_permissions_unavailable(self):
         response = self.client.get(
             "/shared/authorised/some:connection_id",
-            headers={"X-Endpoint-API-UserInfo": TestAuthorised._get_dummy_user_info()},
+            headers={"X-Endpoint-API-UserInfo": self._get_dummy_user_info()},
         )
         assert response.status_code == 403
         assert response.json() == {
@@ -115,7 +115,7 @@ class TestAuthorised(TestAuthBase):
     def test_permissions_available_not_granted(self, mocked_not_given_permissions):
         response = self.client.get(
             "/shared/authorised/some:connection_id",
-            headers={"X-Endpoint-API-UserInfo": TestAuthorised._get_dummy_user_info()},
+            headers={"X-Endpoint-API-UserInfo": self._get_dummy_user_info()},
         )
         assert response.status_code == 403
         assert response.json() == {"detail": "User cannot access this resource"}
@@ -124,7 +124,7 @@ class TestAuthorised(TestAuthBase):
         response = self.client.get(
             "/shared/authorised/some:connection_id",
             headers={
-                "X-Endpoint-API-UserInfo": TestAuthorised._get_dummy_user_info(
+                "X-Endpoint-API-UserInfo": self._get_dummy_user_info(
                     email="bob@burgers.com", name="Bob", app_metadata={"userId": 2}
                 )
             },
@@ -141,7 +141,7 @@ class TestAuthorised(TestAuthBase):
         response = self.client.get(
             "/shared/authorised/some:connection_id",
             headers={
-                "X-Endpoint-API-UserInfo": TestAuthorised._get_dummy_user_info(
+                "X-Endpoint-API-UserInfo": self._get_dummy_user_info(
                     app_metadata={"userId": 2}
                 )
             },
@@ -153,7 +153,7 @@ class TestAuthorised(TestAuthBase):
         response = self.client.get(
             "/shared/authorised/some:connection_id",
             headers={
-                "X-Endpoint-API-UserInfo": TestAuthorised._get_dummy_user_info(
+                "X-Endpoint-API-UserInfo": self._get_dummy_user_info(
                     app_metadata={"userId": 2}
                 )
             },
@@ -165,7 +165,7 @@ class TestAuthorised(TestAuthBase):
         response = self.client.get(
             "/shared/authorised/some:connection_id",
             headers={
-                "X-Endpoint-API-UserInfo": TestAuthorised._get_dummy_user_info(
+                "X-Endpoint-API-UserInfo": self._get_dummy_user_info(
                     internal_metadata={"isServiceAccount": True}
                 )
             },


### PR DESCRIPTION
Changes made to `fluidly-flask` have been ported to `fluidly-fastapi`