### PR TITLE
Fix Session type hint

### DIFF
--- a/fluidly-auth/.bumpversion.cfg
+++ b/fluidly-auth/.bumpversion.cfg
@@ -1,4 +1,4 @@
 [bumpversion]
-current_version = 0.1.2
+current_version = 0.1.3
 
 [bumpversion:file:setup.py]

--- a/fluidly-auth/fluidly/__init__.py
+++ b/fluidly-auth/fluidly/__init__.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 try:
     import pkg_resources
 
@@ -7,4 +5,4 @@ try:
 except ImportError:
     import pkgutil
 
-    __path__: Any = pkgutil.extend_path(__path__, __name__)
+    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/fluidly-auth/setup.py
+++ b/fluidly-auth/setup.py
@@ -11,7 +11,7 @@ URL = "https://github.com/fluidly/python-shared"
 EMAIL = "tech@fluidly.com"
 AUTHOR = "Fluidly"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "0.1.2"
+VERSION = "0.1.3"
 
 
 def local_dependencies(*packages):

--- a/fluidly-fastapi/.bumpversion.cfg
+++ b/fluidly-fastapi/.bumpversion.cfg
@@ -1,4 +1,4 @@
 [bumpversion]
-current_version = 0.1.3
+current_version = 0.1.4
 
 [bumpversion:file:setup.py]

--- a/fluidly-fastapi/fluidly/__init__.py
+++ b/fluidly-fastapi/fluidly/__init__.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 try:
     import pkg_resources
 
@@ -7,4 +5,4 @@ try:
 except ImportError:
     import pkgutil
 
-    __path__: Any = pkgutil.extend_path(__path__, __name__)
+    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/fluidly-fastapi/setup.py
+++ b/fluidly-fastapi/setup.py
@@ -11,7 +11,7 @@ URL = "https://github.com/fluidly/python-shared"
 EMAIL = "tech@fluidly.com"
 AUTHOR = "Fluidly"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "0.1.3"
+VERSION = "0.1.4"
 
 
 def local_dependencies(*packages):

--- a/fluidly-flask/.bumpversion.cfg
+++ b/fluidly-flask/.bumpversion.cfg
@@ -1,4 +1,4 @@
 [bumpversion]
-current_version = 0.1.2
+current_version = 0.1.3
 
 [bumpversion:file:setup.py]

--- a/fluidly-flask/fluidly/__init__.py
+++ b/fluidly-flask/fluidly/__init__.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 try:
     import pkg_resources
 
@@ -7,4 +5,4 @@ try:
 except ImportError:
     import pkgutil
 
-    __path__: Any = pkgutil.extend_path(__path__, __name__)
+    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/fluidly-flask/setup.py
+++ b/fluidly-flask/setup.py
@@ -11,7 +11,7 @@ URL = "https://github.com/fluidly/python-shared"
 EMAIL = "tech@fluidly.com"
 AUTHOR = "Fluidly"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "0.1.2"
+VERSION = "0.1.3"
 
 
 def local_dependencies(*packages):

--- a/fluidly-pipenv/.bumpversion.cfg
+++ b/fluidly-pipenv/.bumpversion.cfg
@@ -1,4 +1,4 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.1.1
 
 [bumpversion:file:setup.py]

--- a/fluidly-pipenv/fluidly/__init__.py
+++ b/fluidly-pipenv/fluidly/__init__.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 try:
     import pkg_resources
 
@@ -7,4 +5,4 @@ try:
 except ImportError:
     import pkgutil
 
-    __path__: Any = pkgutil.extend_path(__path__, __name__)
+    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/fluidly-pipenv/setup.py
+++ b/fluidly-pipenv/setup.py
@@ -11,7 +11,7 @@ URL = "https://github.com/fluidly/python-shared"
 EMAIL = "tech@fluidly.com"
 AUTHOR = "Fluidly"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "0.1.0"
+VERSION = "0.1.1"
 
 
 def local_dependencies(*packages):

--- a/fluidly-pubsub/.bumpversion.cfg
+++ b/fluidly-pubsub/.bumpversion.cfg
@@ -1,4 +1,4 @@
 [bumpversion]
-current_version = 0.1.3
+current_version = 0.1.4
 
 [bumpversion:file:setup.py]

--- a/fluidly-pubsub/fluidly/__init__.py
+++ b/fluidly-pubsub/fluidly/__init__.py
@@ -1,5 +1,3 @@
-from typing import List
-
 try:
     import pkg_resources
 
@@ -7,4 +5,4 @@ try:
 except ImportError:
     import pkgutil
 
-    __path__: List[str] = pkgutil.extend_path(__path__, __name__)
+    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/fluidly-pubsub/setup.py
+++ b/fluidly-pubsub/setup.py
@@ -11,7 +11,7 @@ URL = "https://github.com/fluidly/python-shared"
 EMAIL = "tech@fluidly.com"
 AUTHOR = "Fluidly"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "0.1.3"
+VERSION = "0.1.4"
 
 REQUIRED = ["google-cloud-pubsub"]
 

--- a/fluidly-sqlalchemy/.bumpversion.cfg
+++ b/fluidly-sqlalchemy/.bumpversion.cfg
@@ -1,4 +1,4 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.1.1
 
 [bumpversion:file:setup.py]

--- a/fluidly-sqlalchemy/fluidly/__init__.py
+++ b/fluidly-sqlalchemy/fluidly/__init__.py
@@ -1,5 +1,3 @@
-from typing import List
-
 try:
     import pkg_resources
 
@@ -7,4 +5,4 @@ try:
 except ImportError:
     import pkgutil
 
-    __path__: List[str] = pkgutil.extend_path(__path__, __name__)
+    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/fluidly-sqlalchemy/fluidly/sqlalchemy/db.py
+++ b/fluidly-sqlalchemy/fluidly/sqlalchemy/db.py
@@ -2,15 +2,15 @@ from contextlib import contextmanager
 from typing import Any, Generator
 
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.orm.session import SessionTransaction
+from sqlalchemy.orm.session import Session
 
-sessionmaker = sessionmaker()
+SessionMaker = sessionmaker()
 
 
 @contextmanager
-def db_session() -> Generator[SessionTransaction, Any, Any]:
+def db_session() -> Generator[Session, Any, Any]:
     try:
-        session: SessionTransaction = sessionmaker()
+        session = SessionMaker()
         yield session
     except Exception:
         session.rollback()

--- a/fluidly-sqlalchemy/setup.py
+++ b/fluidly-sqlalchemy/setup.py
@@ -11,7 +11,7 @@ URL = "https://github.com/fluidly/python-shared"
 EMAIL = "tech@fluidly.com"
 AUTHOR = "Fluidly"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "0.1.0"
+VERSION = "0.1.1"
 
 REQUIRED = ["sqlalchemy"]
 

--- a/fluidly-sqlalchemy/tests/test_db.py
+++ b/fluidly-sqlalchemy/tests/test_db.py
@@ -10,7 +10,7 @@ from fluidly.sqlalchemy.db import db_session
 @pytest.fixture()
 def sessionmaker_mock(monkeypatch):
     mock_sessionmaker = mock.MagicMock()
-    monkeypatch.setattr(db, "sessionmaker", mock_sessionmaker)
+    monkeypatch.setattr(db, "SessionMaker", mock_sessionmaker)
     yield mock_sessionmaker
 
 

--- a/fluidly-structlog/.bumpversion.cfg
+++ b/fluidly-structlog/.bumpversion.cfg
@@ -1,4 +1,4 @@
 [bumpversion]
-current_version = 0.1.7
+current_version = 0.1.8
 
 [bumpversion:file:setup.py]

--- a/fluidly-structlog/fluidly/__init__.py
+++ b/fluidly-structlog/fluidly/__init__.py
@@ -1,5 +1,3 @@
-from typing import List
-
 try:
     import pkg_resources
 
@@ -7,4 +5,4 @@ try:
 except ImportError:
     import pkgutil
 
-    __path__: List[str] = pkgutil.extend_path(__path__, __name__)
+    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/fluidly-structlog/setup.py
+++ b/fluidly-structlog/setup.py
@@ -11,7 +11,7 @@ URL = "https://github.com/fluidly/python-shared"
 EMAIL = "tech@fluidly.com"
 AUTHOR = "Fluidly"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "0.1.7"
+VERSION = "0.1.8"
 
 REQUIRED = ["structlog"]
 


### PR DESCRIPTION
Fixing the session type hint
```
>>> from fluidly.sqlalchemy.db import db_session
>>> with db_session() as s:
...     print(type(s))

<class 'sqlalchemy.orm.session.Session'>
```
Also renaming `sessionmaker` so we don't shadow the import as I find it a bit confusing.

Also with the latest mypy we're getting new type errors in a few modules so I removed the type hint as advised in https://github.com/python/mypy/issues/11769