### PR TITLE
Add get subscriber

### DIFF
--- a/fluidly-pubsub/.bumpversion.cfg
+++ b/fluidly-pubsub/.bumpversion.cfg
@@ -1,4 +1,4 @@
 [bumpversion]
-current_version = 0.1.4
+current_version = 0.2.0
 
 [bumpversion:file:setup.py]

--- a/fluidly-pubsub/fluidly/pubsub/subscriber.py
+++ b/fluidly-pubsub/fluidly/pubsub/subscriber.py
@@ -1,4 +1,7 @@
+from typing import Optional
+
 from google.cloud import pubsub_v1
+from google.cloud.pubsub_v1 import SubscriberClient
 
 from fluidly.pubsub.base_subscriber import (
     SubscriptionFutures,
@@ -6,8 +9,17 @@ from fluidly.pubsub.base_subscriber import (
     setup_base_subscriber,
 )
 
-subscriber = pubsub_v1.SubscriberClient()
+_subscriber: Optional[SubscriberClient] = None
+
+
+def get_pubsub_subscriber() -> SubscriberClient:
+    global _subscriber
+
+    if _subscriber is None:
+        _subscriber = pubsub_v1.SubscriberClient()
+    return _subscriber
 
 
 def setup_subscriptions(subscriptions: Subscriptions) -> SubscriptionFutures:
+    subscriber = get_pubsub_subscriber()
     return setup_base_subscriber(subscriber, subscriptions)

--- a/fluidly-pubsub/setup.py
+++ b/fluidly-pubsub/setup.py
@@ -11,7 +11,7 @@ URL = "https://github.com/fluidly/python-shared"
 EMAIL = "tech@fluidly.com"
 AUTHOR = "Fluidly"
 REQUIRES_PYTHON = ">=3.6.0"
-VERSION = "0.1.4"
+VERSION = "0.2.0"
 
 REQUIRED = ["google-cloud-pubsub"]
 


### PR DESCRIPTION
Moving the subscriber setup out of the top level scope and inside the get subscriber function

from going through https://github.com/search?l=Python&p=1&q=subscriber+org%3Afluidly&type=Code it doesn't seem like we're ever importing the subscriber directly so it should be fine